### PR TITLE
feat(*): add more contribution data about ESLint

### DIFF
--- a/docs/contributions.md
+++ b/docs/contributions.md
@@ -25,7 +25,7 @@ Copyright © 2024-2025 [루밀LuMir(lumirlumir)](https://github.com/lumirlumir).
 
 | Issues Created                   | Comments Created                                                                                             |
 | :------------------------------: | :----------------------------------------------------------------------------------------------------------: |
-| More than 15 | More than 13 |
+| More than 17 | More than 13 |
 
 ## Highlights
 
@@ -198,6 +198,12 @@ Copyright © 2024-2025 [루밀LuMir(lumirlumir)](https://github.com/lumirlumir).
 #### :sparkles: Features
 
 1. feat: support front matter [#328](https://github.com/eslint/markdown/pull/328) :green_heart:
+1. feat: support `applyInlineConfig` [#332](https://github.com/eslint/markdown/pull/332) :green_heart:
+1. feat: add missing `mdast` types to `MarkdownRuleVisitor` [#334](https://github.com/eslint/markdown/pull/334) :green_heart:
+
+#### :bug: Bug Fixes
+
+1. fix: replace `IMarkdownSourceCode` with `MarkdownSourceCode` [#336](https://github.com/eslint/markdown/pull/336) :green_heart:
 
 #### :test_tube: Tests
 
@@ -209,6 +215,7 @@ Copyright © 2024-2025 [루밀LuMir(lumirlumir)](https://github.com/lumirlumir).
 1. Bug: ESLint built-in types are not compatible with `mdast` node types [#323](https://github.com/eslint/markdown/issues/323)
 1. Change Request: Support Front Matter [#325](https://github.com/eslint/markdown/issues/325)
 1. Change Request: Support `applyInlineConfig` [#330](https://github.com/eslint/markdown/issues/330)
+1. Change Request: Support Math [#331](https://github.com/eslint/markdown/issues/331)
 
 #### :newspaper: Pull Request Comments
 
@@ -223,6 +230,7 @@ Copyright © 2024-2025 [루밀LuMir(lumirlumir)](https://github.com/lumirlumir).
 #### :speech_balloon: Issues
 
 1. Change Request: Support `getLocFromIndex()` and `getIndexFromLoc()` methods for `TextSourceCodeBase` class [#166](https://github.com/eslint/rewrite/issues/166)
+1. Change Request: Support `getParent`, `getAncestors`, `getText` and `lines` as a optional values for `SourceCodeBase` interface [#175](https://github.com/eslint/rewrite/issues/175)
 
 ### [`eslint.org`](https://github.com/eslint/eslint.org) ![GitHub Repo Stars](https://img.shields.io/github/stars/eslint/eslint.org)
 

--- a/src/data/contributions.js
+++ b/src/data/contributions.js
@@ -689,6 +689,27 @@ export default [
             merged: false,
           },
           {
+            number: 332,
+            type: 'feat',
+            title: 'feat: support `applyInlineConfig`',
+            highlight: true,
+            merged: false,
+          },
+          {
+            number: 334,
+            type: 'feat',
+            title: 'feat: add missing `mdast` types to `MarkdownRuleVisitor`',
+            highlight: true,
+            merged: false,
+          },
+          {
+            number: 336,
+            type: 'fix',
+            title: 'fix: replace `IMarkdownSourceCode` with `MarkdownSourceCode`',
+            highlight: true,
+            merged: false,
+          },
+          {
             number: 329,
             type: 'test',
             title: 'test: create tests for `MarkdownLanguage`',
@@ -719,6 +740,11 @@ export default [
             type: 'feat',
             title: 'Change Request: Support `applyInlineConfig`',
           },
+          {
+            number: 331,
+            type: 'feat',
+            title: 'Change Request: Support Math',
+          },
         ],
         pullRequestComments: [
           {
@@ -746,6 +772,12 @@ export default [
             type: 'feat',
             title:
               'Change Request: Support `getLocFromIndex()` and `getIndexFromLoc()` methods for `TextSourceCodeBase` class',
+          },
+          {
+            number: 175,
+            type: 'fix',
+            title:
+              'Change Request: Support `getParent`, `getAncestors`, `getText` and `lines` as a optional values for `SourceCodeBase` interface',
           },
         ],
       },


### PR DESCRIPTION
This pull request includes updates to the `docs/contributions.md` and `src/data/contributions.js` files, adding new features, bug fixes, and change requests. The most important changes include adding new features and bug fixes, updating the contributions list, and enhancing the documentation.

### Documentation Updates:

* [`docs/contributions.md`](diffhunk://#diff-88440b1d44a319d356349d43ee7f53428faa1c7fd50d75b799719c7c231857b3R201-R206): Added new features such as `applyInlineConfig` and missing `mdast` types to `MarkdownRuleVisitor` [[1]](diffhunk://#diff-88440b1d44a319d356349d43ee7f53428faa1c7fd50d75b799719c7c231857b3R201-R206). Added a new bug fix for replacing `IMarkdownSourceCode` with `MarkdownSourceCode` [[2]](diffhunk://#diff-88440b1d44a319d356349d43ee7f53428faa1c7fd50d75b799719c7c231857b3R201-R206).

### Contributions List Enhancements:

* [`src/data/contributions.js`](diffhunk://#diff-7cdf3ef9fb7dd80c0bda04d785a541f4e6e0b2c0786ddf469561646eef9ebec1R691-R711): Added new feature entries for `applyInlineConfig` and missing `mdast` types to `MarkdownRuleVisitor` [[1]](diffhunk://#diff-7cdf3ef9fb7dd80c0bda04d785a541f4e6e0b2c0786ddf469561646eef9ebec1R691-R711). Added a new bug fix entry for replacing `IMarkdownSourceCode` with `MarkdownSourceCode` [[2]](diffhunk://#diff-7cdf3ef9fb7dd80c0bda04d785a541f4e6e0b2c0786ddf469561646eef9ebec1R691-R711).
* [`docs/contributions.md`](diffhunk://#diff-88440b1d44a319d356349d43ee7f53428faa1c7fd50d75b799719c7c231857b3R218): Included new change requests such as support for Math and `getParent`, `getAncestors`, `getText`, and `lines` as optional values for `SourceCodeBase` interface [[1]](diffhunk://#diff-88440b1d44a319d356349d43ee7f53428faa1c7fd50d75b799719c7c231857b3R218) [[2]](diffhunk://#diff-88440b1d44a319d356349d43ee7f53428faa1c7fd50d75b799719c7c231857b3R233).
* [`src/data/contributions.js`](diffhunk://#diff-7cdf3ef9fb7dd80c0bda04d785a541f4e6e0b2c0786ddf469561646eef9ebec1R743-R747): Added new change request entries for supporting Math and optional values for `SourceCodeBase` interface [[1]](diffhunk://#diff-7cdf3ef9fb7dd80c0bda04d785a541f4e6e0b2c0786ddf469561646eef9ebec1R743-R747) [[2]](diffhunk://#diff-7cdf3ef9fb7dd80c0bda04d785a541f4e6e0b2c0786ddf469561646eef9ebec1R776-R781).