### PR TITLE
feat(*): add more contributions

### DIFF
--- a/docs/contributions.md
+++ b/docs/contributions.md
@@ -214,6 +214,7 @@ Copyright © 2024-2025 [루밀LuMir(lumirlumir)](https://github.com/lumirlumir).
 
 1. chore: create `PULL_REQUEST_TEMPLATE.md` [#337](https://github.com/eslint/markdown/pull/337) :purple_heart:
 1. chore: add eslint fix command for Markdown files in lint-staged [#343](https://github.com/eslint/markdown/pull/343) :purple_heart:
+1. chore: bump `@eslint/core` and `@eslint/plugin-kit` to latest [#345](https://github.com/eslint/markdown/pull/345) :green_heart:
 
 #### :memo: Documentation
 
@@ -241,7 +242,7 @@ Copyright © 2024-2025 [루밀LuMir(lumirlumir)](https://github.com/lumirlumir).
 #### :newspaper: Issue Comments
 
 1. Bug: False positive `markdown/no-missing-label-refs` on GFM Alerts [#294](https://github.com/eslint/markdown/issues/294#issuecomment-2763192768)
-1. Bug: False positive with no-missing-label-refs on checkboxes [#335](https://github.com/eslint/markdown/issues/335##issuecomment-2804399639)
+1. Bug: False positive with no-missing-label-refs on checkboxes [#335](https://github.com/eslint/markdown/issues/335#issuecomment-2804399639)
 
 ### [`rewrite`](https://github.com/eslint/rewrite) ![GitHub Repo Stars](https://img.shields.io/github/stars/eslint/rewrite)
 

--- a/docs/contributions.md
+++ b/docs/contributions.md
@@ -15,17 +15,17 @@ Copyright © 2024-2025 [루밀LuMir(lumirlumir)](https://github.com/lumirlumir).
 
 | Contributed Organizations                | Contributed Repositories                | Merged Pull Requests                         |
 | :--------------------------------------: | :-------------------------------------: | :------------------------------------------: |
-| 18 | 22 | More than 105 |
+| 18 | 22 | More than 108 |
 
 | :sparkles: feat | :bug: fix | :hammer_and_wrench: build | :toolbox: chore | :arrows_counterclockwise: ci | :memo: docs | :zap: perf | :recycle: refactor | :art: style | :test_tube: test |
 | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
-| 10 | 11 | 0 | 16 | 0 | 65 | 0 | 0 | 1 | 2 |
+| 11 | 12 | 0 | 17 | 0 | 65 | 0 | 0 | 1 | 2 |
 
 ### Others
 
 | Issues Created                   | Comments Created                                                                                             |
 | :------------------------------: | :----------------------------------------------------------------------------------------------------------: |
-| More than 22 | More than 14 |
+| More than 22 | More than 15 |
 
 ## Highlights
 
@@ -203,15 +203,17 @@ Copyright © 2024-2025 [루밀LuMir(lumirlumir)](https://github.com/lumirlumir).
 
 1. feat: support front matter [#328](https://github.com/eslint/markdown/pull/328) :purple_heart:
 1. feat: support `eslint` config comments [#332](https://github.com/eslint/markdown/pull/332) :purple_heart:
-1. feat: add missing `mdast` types to `MarkdownRuleVisitor` [#334](https://github.com/eslint/markdown/pull/334) :green_heart:
+1. feat: add missing `mdast` types to `MarkdownRuleVisitor` [#334](https://github.com/eslint/markdown/pull/334) :purple_heart:
 
 #### :bug: Bug Fixes
 
 1. fix: replace `IMarkdownSourceCode` with `MarkdownSourceCode` [#336](https://github.com/eslint/markdown/pull/336) :purple_heart:
+1. fix: enhance fenced code language rule to support tilde as a delimiter [#344](https://github.com/eslint/markdown/pull/344) :purple_heart:
 
 #### :toolbox: Chores
 
 1. chore: create `PULL_REQUEST_TEMPLATE.md` [#337](https://github.com/eslint/markdown/pull/337) :purple_heart:
+1. chore: add eslint fix command for Markdown files in lint-staged [#343](https://github.com/eslint/markdown/pull/343) :purple_heart:
 
 #### :memo: Documentation
 
@@ -239,6 +241,7 @@ Copyright © 2024-2025 [루밀LuMir(lumirlumir)](https://github.com/lumirlumir).
 #### :newspaper: Issue Comments
 
 1. Bug: False positive `markdown/no-missing-label-refs` on GFM Alerts [#294](https://github.com/eslint/markdown/issues/294#issuecomment-2763192768)
+1. Bug: False positive with no-missing-label-refs on checkboxes [#335](https://github.com/eslint/markdown/issues/335##issuecomment-2804399639)
 
 ### [`rewrite`](https://github.com/eslint/rewrite) ![GitHub Repo Stars](https://img.shields.io/github/stars/eslint/rewrite)
 

--- a/src/data/contributions.js
+++ b/src/data/contributions.js
@@ -755,6 +755,12 @@ export default [
             highlight: true,
             merged: true,
           },
+          {
+            number: 345,
+            type: 'chore',
+            title: 'chore: bump `@eslint/core` and `@eslint/plugin-kit` to latest',
+            merged: false,
+          },
         ],
         issues: [
           {
@@ -819,7 +825,7 @@ export default [
           {
             number: 335,
             title: 'Bug: False positive with no-missing-label-refs on checkboxes',
-            fragment: '#issuecomment-2804399639',
+            fragment: 'issuecomment-2804399639',
           },
         ],
       },

--- a/src/data/contributions.js
+++ b/src/data/contributions.js
@@ -711,7 +711,7 @@ export default [
             title: 'feat: add missing `mdast` types to `MarkdownRuleVisitor`',
             description: 'contributor pool',
             highlight: true,
-            merged: false,
+            merged: true,
           },
           {
             number: 336,
@@ -738,6 +738,21 @@ export default [
             number: 342,
             type: 'docs',
             title: 'docs: fix inaccurate description in `no-html.md`',
+            merged: true,
+          },
+          {
+            number: 343,
+            type: 'chore',
+            title: 'chore: add eslint fix command for Markdown files in lint-staged',
+            merged: true,
+          },
+          {
+            number: 344,
+            type: 'fix',
+            title:
+              'fix: enhance fenced code language rule to support tilde as a delimiter',
+            description: 'contributor pool',
+            highlight: true,
             merged: true,
           },
         ],
@@ -800,6 +815,11 @@ export default [
             title: 'Bug: False positive `markdown/no-missing-label-refs` on GFM Alerts',
             fragment: 'issuecomment-2763192768',
             highlight: true,
+          },
+          {
+            number: 335,
+            title: 'Bug: False positive with no-missing-label-refs on checkboxes',
+            fragment: '#issuecomment-2804399639',
           },
         ],
       },


### PR DESCRIPTION
This pull request updates contribution statistics and adds new entries to both the documentation and the contributions data file. The most important changes include updating contribution metrics, adding new features, bug fixes, and chores to the documentation, and synchronizing these updates with the `src/data/contributions.js` file.

### Updates to Contribution Metrics:
* Updated the number of merged pull requests from "More than 105" to "More than 108" and incremented counts for `:sparkles: feat`, `:bug: fix`, and `:hammer_and_wrench: build` categories in `docs/contributions.md`.

### Documentation Updates:
* Changed the emoji for the `feat: add missing mdast types to MarkdownRuleVisitor` entry from :green_heart: to :purple_heart: and added entries for a new bug fix and chore.
* Added a new issue comment entry for a bug related to false positives with `no-missing-label-refs` on checkboxes.

### Synchronization with `src/data/contributions.js`:
* Marked the `feat: add missing mdast types to MarkdownRuleVisitor` entry as merged.
* Added new entries for the chore `add eslint fix command for Markdown files in lint-staged` and the bug fix `enhance fenced code language rule to support tilde as a delimiter`.
* Added a new issue comment entry for the bug `False positive with no-missing-label-refs on checkboxes`.