### PR TITLE
chore(*): update ESLint config file

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,13 +1,15 @@
+import { defineConfig, globalIgnores } from 'eslint/config';
 import bananass from 'eslint-config-bananass';
 import mark from 'eslint-plugin-mark';
 
 /** @type {import("eslint").Linter.Config[]} */
-export default [
-  {
-    name: 'global/ignores',
-    ignores: ['**/build/', '**/coverage/', '**/.vitepress/cache/'],
-  },
+export default defineConfig([
+  globalIgnores(['**/build/', '**/coverage/', '**/.vitepress/cache/'], 'global/ignores'),
+
   bananass.configs.js,
   bananass.configs.ts,
+  bananass.configs.json,
+  bananass.configs.jsonc,
+  bananass.configs.json5,
   mark.configs.recommendedGfm,
-];
+]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,19 +9,19 @@
         "concurrently": "^9.2.1",
         "editorconfig-checker": "^6.1.0",
         "eslint": "^9.37.0",
-        "eslint-config-bananass": "^0.4.1",
-        "eslint-plugin-mark": "^0.1.0-canary.7",
+        "eslint-config-bananass": "^0.5.0",
+        "eslint-plugin-mark": "^0.1.0-canary.8",
         "husky": "^9.1.7",
         "lint-staged": "^16.2.3",
         "markdownlint-cli": "^0.45.0",
         "prettier": "^3.6.2",
-        "prettier-config-bananass": "^0.4.1",
+        "prettier-config-bananass": "^0.5.0",
         "textlint": "^14.7.2",
         "textlint-rule-allowed-uris": "^2.0.1",
         "typescript": "^5.9.3"
       },
       "engines": {
-        "node": ">=20.18.0"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -559,24 +559,41 @@
         "url": "https://eslint.org/donate"
       }
     },
+    "node_modules/@eslint/json": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@eslint/json/-/json-0.13.2.tgz",
+      "integrity": "sha512-yWLyRE18rHgHXhWigRpiyv1LDPkvWtC6oa7QHXW7YdP6gosJoq7BiLZW2yCs9U7zN7X4U3ZeOJjepA10XAOIMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.15.2",
+        "@eslint/plugin-kit": "^0.3.5",
+        "@humanwhocodes/momoa": "^3.3.9",
+        "natural-compare": "^1.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@eslint/markdown": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/markdown/-/markdown-7.1.0.tgz",
-      "integrity": "sha512-Y+X1B1j+/zupKDVJfkKc8uYMjQkGzfnd8lt7vK3y8x9Br6H5dBuhAfFrQ6ff7HAMm/1BwgecyEiRFkYCWPRxmA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/markdown/-/markdown-7.3.0.tgz",
+      "integrity": "sha512-v9Cpl9IvzGmWMUwDAwSbf1b2GMwjQJiD0TSHegFrIu23mjqGQOvaCwnetzbG3/fjk8x7baKaIbSTBlpCktZRRg==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
         "examples/*"
       ],
       "dependencies": {
-        "@eslint/core": "^0.15.1",
-        "@eslint/plugin-kit": "^0.3.4",
+        "@eslint/core": "^0.15.2",
+        "@eslint/plugin-kit": "^0.3.5",
         "github-slugger": "^2.0.0",
         "mdast-util-from-markdown": "^2.0.2",
         "mdast-util-frontmatter": "^2.0.1",
         "mdast-util-gfm": "^3.1.0",
         "micromark-extension-frontmatter": "^2.0.0",
-        "micromark-extension-gfm": "^3.0.0"
+        "micromark-extension-gfm": "^3.0.0",
+        "micromark-util-normalize-identifier": "^2.0.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1064,6 +1081,16 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@humanwhocodes/momoa": {
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-3.3.9.tgz",
+      "integrity": "sha512-LHw6Op4bJb3/3KZgOgwflJx5zY9XOy0NU1NuyUFKGdTwHYmP+PbnQGCYQJ8NVNlulLfQish34b0VuUlLYP3AXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
@@ -1236,9 +1263,9 @@
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "15.5.3",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.3.tgz",
-      "integrity": "sha512-SdhaKdko6dpsSr0DldkESItVrnPYB1NS2NpShCSX5lc7SSQmLZt5Mug6t2xbiuVWEVDLZSuIAoQyYVBYp0dR5g==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.4.tgz",
+      "integrity": "sha512-SR1vhXNNg16T4zffhJ4TS7Xn7eq4NfKfcOsRwea7RIAHrjRpI9ALYbamqIJqkAhowLlERffiwk0FMvTLNdnVtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3082,16 +3109,16 @@
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
-      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.18.2",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.2.tgz",
-      "integrity": "sha512-6Jw4sE1maoRJo3q8MsSIn2onJFbLTOjY9hlx4DZXmOKvLRd1Ok2kXmAGXaafL2+ijsJZ1ClYbl/pmqr9+k4iUQ==",
+      "version": "5.18.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
+      "integrity": "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3429,25 +3456,26 @@
       }
     },
     "node_modules/eslint-config-bananass": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-bananass/-/eslint-config-bananass-0.4.1.tgz",
-      "integrity": "sha512-wGuGD7un2wedkYUCCvD7+o2RnG7vc3VAi14fUHvb5cmMj/YjTb0Dz8lonAi/UKIapYV+yXFC/CT6V248G/H0Fg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-bananass/-/eslint-config-bananass-0.5.0.tgz",
+      "integrity": "sha512-dsmj+IuMCRYvJCL2c1gI4VyL6aF2kDMPMgQMieeB8m+oVvuHR7W90d9GJ4TPTbgT/yGgFDeM0YNZbK81Y/0Zvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "^15.5.3",
+        "@eslint/json": "^0.13.2",
+        "@next/eslint-plugin-next": "^15.5.4",
         "@stylistic/eslint-plugin-js": "^4.4.1",
         "@typescript-eslint/eslint-plugin": "^8.43.0",
         "@typescript-eslint/parser": "^8.43.0",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
-        "eslint-plugin-n": "^17.21.3",
+        "eslint-plugin-n": "^17.23.1",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^6.0.0-rc.2",
         "globals": "^16.4.0"
       },
       "peerDependencies": {
-        "eslint": "^9.0.0"
+        "eslint": "^9.15.0"
       }
     },
     "node_modules/eslint-config-bananass/node_modules/globals": {
@@ -3617,24 +3645,24 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-mark": {
-      "version": "0.1.0-canary.7",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mark/-/eslint-plugin-mark-0.1.0-canary.7.tgz",
-      "integrity": "sha512-E8ThX8A6LgJiVc2JYwhQwQEWYgeD9oarK1MCgedhRVMw6sQfnl3E/XpBFyHFGYGQREOXvgf3PVWIH40cAm0M1Q==",
+      "version": "0.1.0-canary.8",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mark/-/eslint-plugin-mark-0.1.0-canary.8.tgz",
+      "integrity": "sha512-LFLOPajyYsAVejn81XFmouFjA9fCvXNf+szcMtKY1wwZsKgSemNcuwSBEPb/kaNEfSTwrlTmQz3Qe1Lr3eNMOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint/markdown": "^7.1.0",
-        "emoji-regex": "^10.4.0",
+        "@eslint/markdown": "^7.3.0",
+        "emoji-regex": "^10.5.0",
         "parse5": "^8.0.0"
       },
       "peerDependencies": {
-        "eslint": "^9.0.0"
+        "eslint": "^9.15.0"
       }
     },
     "node_modules/eslint-plugin-n": {
-      "version": "17.21.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.21.3.tgz",
-      "integrity": "sha512-MtxYjDZhMQgsWRm/4xYLL0i2EhusWT7itDxlJ80l1NND2AL2Vi5Mvneqv/ikG9+zpran0VsVRXTEHrpLmUZRNw==",
+      "version": "17.23.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.23.1.tgz",
+      "integrity": "sha512-68PealUpYoHOBh332JLLD9Sj7OQUDkFpmcfqt8R9sySfFSeuGJjMTJQvCRRB96zO3A/PELRLkPrzsHmzEFQQ5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8261,9 +8289,9 @@
       }
     },
     "node_modules/prettier-config-bananass": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/prettier-config-bananass/-/prettier-config-bananass-0.4.1.tgz",
-      "integrity": "sha512-IX6XDOiz2AN/uCpKpyKAA7bLBWbRJwbe88YhDjomJfqCLZXTp/lAhhBbFqOvrdr/mVZgJYNPdcNpfaVOYKlQJQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/prettier-config-bananass/-/prettier-config-bananass-0.5.0.tgz",
+      "integrity": "sha512-HITx7i8jMSvDnzR02EOkhoyF7j88OlH5u+GT6LjO5Cpt3Upo8v+ybWbsqeIpwPMxBum8G3MnlkDT5oz0qWlhAQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -9527,13 +9555,17 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
-      "integrity": "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/text-table": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "packageManager": "npm@10.9.2",
   "engines": {
-    "node": ">=20.18.0"
+    "node": ">=20.19.4"
   },
   "scripts": {
     "prepare": "husky",
@@ -26,13 +26,13 @@
     "concurrently": "^9.2.1",
     "editorconfig-checker": "^6.1.0",
     "eslint": "^9.37.0",
-    "eslint-config-bananass": "^0.4.1",
-    "eslint-plugin-mark": "^0.1.0-canary.7",
+    "eslint-config-bananass": "^0.5.0",
+    "eslint-plugin-mark": "^0.1.0-canary.8",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.3",
     "markdownlint-cli": "^0.45.0",
     "prettier": "^3.6.2",
-    "prettier-config-bananass": "^0.4.1",
+    "prettier-config-bananass": "^0.5.0",
     "textlint": "^14.7.2",
     "textlint-rule-allowed-uris": "^2.0.1",
     "typescript": "^5.9.3"


### PR DESCRIPTION
This pull request updates the ESLint configuration and related dependencies to improve linting coverage and keep the toolchain up to date. The main changes include refactoring the `eslint.config.mjs` file to use modern configuration methods, expanding linting support for JSON formats, and upgrading several linting-related packages.

**ESLint configuration improvements:**

* Refactored `eslint.config.mjs` to use `defineConfig` and `globalIgnores` from `eslint/config`, simplifying the configuration and improving maintainability.
* Added support for additional JSON formats (`json`, `jsonc`, `json5`) in the ESLint configuration for broader linting coverage.

**Dependency updates:**

* Upgraded `eslint-config-bananass`, `eslint-plugin-mark`, and `prettier-config-bananass` to their latest versions for improved features and compatibility.
* Updated the minimum required Node.js version to `20.19.4` in `package.json` to ensure compatibility with the latest tooling.